### PR TITLE
add instruction to replace upstream repo to correct values

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,15 @@ From the templated repository:
 
 Search-replace the following occurrences with the corresponding names.
 
-| Search | Replace With                                                                   |
-| ------ | ------------------------------------------------------------------------------ |
-| xyz    | Lower-cased name of the provider                                               |
-| Xyz    | Pascal-case name of the provider                                               |
-| XYZ    | Upper-cased name of the provider                                               |
-| x_y_z  | Lower snake-cased name of the provider if the provider name has multiple words |
+| Search                                    | Replace With                                                                   |
+| ----------------------------------------- | ------------------------------------------------------------------------------ |
+| github.com/cloudy-sky-software/pulumi-xyz | Remote location of your repository                                             |
+| xyz                                       | Lower-cased name of the provider                                               |
+| Xyz                                       | Pascal-case name of the provider                                               |
+| XYZ                                       | Upper-cased name of the provider                                               |
+| x_y_z                                     | Lower snake-cased name of the provider if the provider name has multiple words |
+
+Update the `Homepage` and `Publisher` values in `provider/pkg/gen/schema.go - PulumiSchema` appropriately.
 
 #### Embed the OpenAPI spec
 


### PR DESCRIPTION
The template assumes that it's being used in the `cloudy-sky-software` GitHub organization. Anyone using this template will need to update the upstream URL to their own new repo.